### PR TITLE
fix(ci): install deps before event mirrors scripts

### DIFF
--- a/.github/workflows/event-mirrors.yml
+++ b/.github/workflows/event-mirrors.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install dependencies
+        run: npm ci
       - name: Generate event mirrors
         run: node scripts/generate-event-mirrors.mjs
 
@@ -54,5 +56,3 @@ jobs:
             }
 
 
-      - name: Install dependencies
-        run: npm ci


### PR DESCRIPTION
Fixes Event Mirrors workflow failing with ERR_MODULE_NOT_FOUND (fast-xml-parser) by running npm ci before generate-event-mirrors.mjs.
No data/mirror files included; workflow-only change.