### PR TITLE
RVCI: new workflow file to fix dispatch

### DIFF
--- a/.github/workflows/rvci-engine.yml
+++ b/.github/workflows/rvci-engine.yml
@@ -1,0 +1,38 @@
+name: rvci-engine-dispatchable
+
+on:
+  schedule:
+    - cron: "30 23 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  rvci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -r backend/rvci/requirements.txt
+      - name: Run RVCI daily build
+        run: python backend/rvci/run_daily.py
+      - name: Commit outputs if changed
+        run: |
+          git config user.name "rvci-bot"
+          git config user.email "rvci-bot@users.noreply.github.com"
+          git add public/data/rvci || true
+test -f public/data/rvci_latest.json && git add public/data/rvci_latest.json || true
+          if git diff --cached --quiet; then
+            echo "No RVCI changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(data): update rvci engine"
+          git push
+
+# rvci-reindex-touch: 2026-01-12T10:07:11Z


### PR DESCRIPTION
GitHub keeps returning 422 for rvci.yml workflow_dispatch; add rvci-engine.yml (new workflow ID) to make manual dispatch reliable.