### PR TITLE
RVCI: unbreak workflow_dispatch parsing

### DIFF
--- a/.github/workflows/rvci-engine.yml
+++ b/.github/workflows/rvci-engine.yml
@@ -1,10 +1,8 @@
 name: rvci-engine-dispatchable
-
-on:
+"on":
   schedule:
     - cron: "30 23 * * 1-5"
-  workflow_dispatch:
-
+  workflow_dispatch: {}
 jobs:
   rvci:
     runs-on: ubuntu-latest

--- a/.github/workflows/rvci.yml
+++ b/.github/workflows/rvci.yml
@@ -1,10 +1,8 @@
 name: rvci-engine
-
-on:
+"on":
   schedule:
     - cron: "30 23 * * 1-5"
-  workflow_dispatch:
-
+  workflow_dispatch: {}
 jobs:
   rvci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make workflow_dispatch parsing unambiguous (quote "on" and use workflow_dispatch: {}).