### PR TITLE
fix(ci): canonical rvci workflow_dispatch

### DIFF
--- a/.github/workflows/rvci-engine.yml
+++ b/.github/workflows/rvci-engine.yml
@@ -1,8 +1,8 @@
 name: rvci-engine-dispatchable
-"on":
+on:
+  workflow_dispatch:
   schedule:
     - cron: "30 23 * * 1-5"
-  workflow_dispatch: {}
 jobs:
   rvci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make rvci-engine workflow_dispatch canonical (on: + workflow_dispatch:) so GitHub registers dispatch reliably.