### PR TITLE
fix(ci): repair rvci workflow bash syntax

### DIFF
--- a/.github/workflows/rvci-engine.yml
+++ b/.github/workflows/rvci-engine.yml
@@ -25,7 +25,8 @@ jobs:
           git config user.name "rvci-bot"
           git config user.email "rvci-bot@users.noreply.github.com"
           git add public/data/rvci || true
-          test -f public/data/rvci_latest.json && git add public/data/rvci_latest.json || true          if git diff --cached --quiet; then
+          test -f public/data/rvci_latest.json && git add public/data/rvci_latest.json || true
+          if git diff --cached --quiet; then
             echo "No RVCI changes to commit."
             exit 0
           fi


### PR DESCRIPTION
Fix glued bash lines in rvci-engine workflow that caused syntax error near 'then'.